### PR TITLE
Add missing `type` property in buildRunningAmounts

### DIFF
--- a/src/lib/Modals/Wallet/Streaming/Streaming.svelte
+++ b/src/lib/Modals/Wallet/Streaming/Streaming.svelte
@@ -155,6 +155,7 @@
           customKey: d.customKey,
           customValue: d.customValue,
           fee: d.fee,
+          type: d.type,
         };
       }
     }


### PR DESCRIPTION
This seems to have been preventing streaming payments from going through. Curiohoster filters on lnaddress/node types and these got filtered out for having no type.