### PR TITLE
Ignore null balance response from Alby

### DIFF
--- a/src/functions/refreshAlbyToken.js
+++ b/src/functions/refreshAlbyToken.js
@@ -27,7 +27,7 @@ export default async function refreshAlbyToken() {
     const data = await response.text();
     try {
       const user = JSON.parse(data);
-      if (user.balance !== undefined) {
+      if (user.balance !== undefined && user.balance !== null) {
         satBalance.set(user.balance);
         lastAlbyRefreshTime.set(currentTime);
         return true;


### PR DESCRIPTION
The Alby API to my cloud node sometimes times out and returns a null balance. This causes Curiocaster to think that I have a zero balance and turn off sat streaming.